### PR TITLE
refactor: replace redirect click counter with client-side POST request

### DIFF
--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -1,13 +1,11 @@
 import { db } from '@/lib/db';
 import { notFound } from 'next/navigation';
 import { getBookmarksWithTags } from '@/lib/bookmarks';
-import { Bookmark } from '@/types/bookmark';
 import { Collection } from '@/types/collection';
-import { Tag } from '@/types/tag';
-import { TagBadge } from '@/components/tag/tag-badge';
-import { ExternalLink, FolderOpen } from 'lucide-react';
-import { Heading, Link, Text } from '@/components/ui/typography';
+import { FolderOpen } from 'lucide-react';
+import { Heading, Text } from '@/components/ui/typography';
 import { Metadata } from 'next';
+import { PublicBookmarkCard } from './public-bookmark-card';
 
 type Props = {
   params: Promise<{ username: string }>;
@@ -111,42 +109,5 @@ export default async function PublicProfilePage({ params }: Props) {
         </section>
       )}
     </div>
-  );
-}
-
-function PublicBookmarkCard({ bookmark }: { bookmark: Bookmark }) {
-  return (
-    <Link
-      href={bookmark.url}
-      target="_blank"
-      className="group flex items-start gap-3 rounded-lg border bg-card p-4 shadow-sm transition-colors hover:bg-muted/50 no-underline"
-    >
-      {bookmark.favicon ? (
-        <img src={bookmark.favicon} alt="" className="mt-0.5 size-4 shrink-0 rounded-sm" />
-      ) : (
-        <div className="mt-0.5 size-4 shrink-0 rounded-sm bg-muted" />
-      )}
-
-      <div className="min-w-0 flex-1">
-        <div className="flex items-start justify-between gap-2">
-          <span className="font-medium group-hover:underline">{bookmark.title}</span>
-          <ExternalLink className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
-        </div>
-
-        {bookmark.description && (
-          <p className="mt-1 text-sm text-muted-foreground">{bookmark.description}</p>
-        )}
-
-        <p className="mt-1 truncate text-xs text-muted-foreground">{bookmark.url}</p>
-
-        {bookmark.tags && bookmark.tags.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-1">
-            {bookmark.tags.map((tag: Tag) => (
-              <TagBadge key={tag.id} tag={tag} />
-            ))}
-          </div>
-        )}
-      </div>
-    </Link>
   );
 }

--- a/src/app/[username]/public-bookmark-card.tsx
+++ b/src/app/[username]/public-bookmark-card.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Bookmark } from '@/types/bookmark';
+import { Tag } from '@/types/tag';
+import { ExternalLink } from 'lucide-react';
+import Link from 'next/link';
+import { TagBadge } from '@/components/tag/tag-badge';
+
+export function PublicBookmarkCard({ bookmark }: { bookmark: Bookmark }) {
+  async function handleClick() {
+    fetch(`/api/bookmarks/click/${bookmark.id}`, {
+      method: 'POST',
+      keepalive: true,
+    });
+  }
+
+  return (
+    <Link
+      href={bookmark.url}
+      onClick={handleClick}
+      target="_blank"
+      className="group flex items-start gap-3 rounded-lg border bg-card p-4 shadow-sm transition-colors hover:bg-muted/50 no-underline"
+    >
+      {bookmark.favicon ? (
+        <img src={bookmark.favicon} alt="" className="mt-0.5 size-4 shrink-0 rounded-sm" />
+      ) : (
+        <div className="mt-0.5 size-4 shrink-0 rounded-sm bg-muted" />
+      )}
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <span className="font-medium group-hover:underline">{bookmark.title}</span>
+          <ExternalLink className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+        </div>
+
+        {bookmark.description && (
+          <p className="mt-1 text-sm text-muted-foreground">{bookmark.description}</p>
+        )}
+
+        <p className="mt-1 truncate text-xs text-muted-foreground">{bookmark.url}</p>
+
+        {bookmark.tags && bookmark.tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {bookmark.tags.map((tag: Tag) => (
+              <TagBadge key={tag.id} tag={tag} />
+            ))}
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/src/app/api/bookmarks/click/[id]/route.ts
+++ b/src/app/api/bookmarks/click/[id]/route.ts
@@ -17,22 +17,3 @@ export async function POST(
 
   return NextResponse.json({ success: true });
 }
-
-// ← adiciona GET para redirect
-export async function GET(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
-  const redirect = req.nextUrl.searchParams.get('redirect');
-
-  const bookmark = await db('bookmarks').where({ id }).first();
-
-  if (!bookmark || !redirect) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  }
-
-  await db('bookmarks').where({ id }).increment('click_count', 1);
-
-  return NextResponse.redirect(redirect);
-}


### PR DESCRIPTION
## What changed
Instead of redirecting through `/api/bookmarks/click/[id]?redirect=...`, 
the public profile page now fires a `POST` request directly from the client 
using `fetch` with `keepalive: true` before opening the link.

## Why
- Simpler API route — only `POST` remains, `GET` with redirect is removed
- `keepalive: true` guarantees the request completes even after navigation
- Cleaner `PublicBookmarkCard` with a standard `<Link>` and `onClick`

## Changes
- `src/app/[username]/page.tsx` — added `handleClick` with `fetch` + `keepalive`
- `src/app/api/bookmarks/click/[id]/route.ts` — removed `GET` handler